### PR TITLE
feat(broker): add simple /status

### DIFF
--- a/comet/broker.py
+++ b/comet/broker.py
@@ -96,24 +96,53 @@ async def status(request):
     """
     Get status of CoMeT (dataset-broker).
 
-    Shows all datasets and states registered by CoMeT (the broker).
+    Poke comet to see if it's alive. Is either dead or returns {"running": True}.
 
     curl -X GET http://localhost:12050/status
     """
-    global states
-    global datasets
-
     logger.debug("status: Received status request")
+    return response.json({"running": True, "result": "success"})
 
-    reply = dict()
+
+@app.route("/states", methods=["GET"])
+async def get_states(request):
+    """
+    Get states from CoMeT (dataset-broker).
+
+    Shows all states registered by CoMeT (the broker).
+
+    curl -X GET http://localhost:12050/states
+    """
+    global states
+
+    logger.debug("status: Received states request")
+
+    reply = {"result": "success"}
     async with lock_states:
         reply["states"] = states.keys()
+
+    logger.debug("states: {}".format(states.keys()))
+    return response.json(reply)
+
+
+@app.route("/datasets", methods=["GET"])
+async def get_datasets(request):
+    """
+    Get datasets from CoMeT (dataset-broker).
+
+    Shows all datasets registered by CoMeT (the broker).
+
+    curl -X GET http://localhost:12050/datasets
+    """
+    global datasets
+
+    logger.debug("status: Received datasets request")
+
+    reply = {"result": "success"}
     async with lock_datasets:
         reply["datasets"] = datasets.keys()
 
-    logger.debug("states: {}".format(states.keys()))
     logger.debug("datasets: {}".format(datasets.keys()))
-
     return response.json(reply)
 
 

--- a/comet/manager.py
+++ b/comet/manager.py
@@ -14,6 +14,9 @@ REGISTER_STATE = "/register-state"
 REGISTER_DATASET = "/register-dataset"
 SEND_STATE = "/send-state"
 REGISTER_EXTERNAL_STATE = "/register-external-state"
+STATUS = "/status"
+STATES = "/states"
+DATASETS = "/datasets"
 
 TIMESTAMP_FORMAT = "%Y-%m-%d-%H:%M:%S.%f"
 
@@ -345,9 +348,10 @@ class Manager:
 
         return ds_id
 
-    def _send(self, endpoint, data):
+    def _send(self, endpoint, data, rtype="post"):
+        command = getattr(requests, rtype)
         try:
-            reply = requests.post(
+            reply = command(
                 self.broker + endpoint, data=json.dumps(data), timeout=TIMEOUT
             )
             reply.raise_for_status()
@@ -457,3 +461,41 @@ class Manager:
             The requested dataset. Returns `None` if requested dataset not found.
         """
         return self.datasets.get(dataset_id, None)
+
+    def broker_status(self):
+        """
+        Get dataset broker status.
+
+        Returns
+        -------
+        bool
+            True if broker is running.
+        """
+        response = self._send(STATUS, None, "get")
+        if "running" not in response:
+            return False
+        return response["running"]
+
+    def _get_states(self):
+        """
+        Get all state IDs known to dataset broker.
+
+        Returns
+        -------
+        List[int]
+            All state IDs known to dataset broker.
+        """
+        response = self._send(STATES, None, "get")
+        return response["states"]
+
+    def _get_datasets(self):
+        """
+        Get all dataset IDs known to dataset broker.
+
+        Returns
+        -------
+        List[int]
+            All dataset IDs known to dataset broker.
+        """
+        response = self._send(DATASETS, None, "get")
+        return response["datasets"]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -151,6 +151,7 @@ def test_recover(manager, broker, simple_ds):
 
     # Give archiver a moment and make broker release dump file by registering another state.
     time.sleep(2)
+    assert manager.broker_status()
     manager.register_config({"blubb": 1})
     time.sleep(0.1)
 
@@ -189,3 +190,8 @@ def test_archiver(archiver, simple_ds, manager):
     assert state.data == {"foo": "bar", "type": "test"}
 
     chimedb.close()
+
+
+def test_status(simple_ds, manager):
+    assert simple_ds[0] in manager._get_datasets()
+    assert simple_ds[1] in manager._get_states()


### PR DESCRIPTION
The /status endpoint was returning all dataset and state IDs.

- Remove /status
- Add simple status that returns {"running": True}
- Add /states endpoint that returns all state IDs
- Add /datasets endpoint that returns all dataset IDs

Closes #36