### PR TITLE
fix(redis_async_locks): move timeout into cond variable

### DIFF
--- a/comet/broker.py
+++ b/comet/broker.py
@@ -179,7 +179,8 @@ async def register_dataset(request):
     )
     dataset_valid = await check_dataset(ds)
     reply = dict()
-    root = await find_root(hash, ds)
+    if dataset_valid:
+        root = await find_root(hash, ds)
 
     # Lack datasets and check if dataset already known.
     async with lock_datasets as r:

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -27,8 +27,8 @@ DEFAULT_PORT = 12050
 REDIS_SERVER = ("localhost", 6379)
 
 app = Sanic(__name__)
-app.config.REQUEST_TIMEOUT = 600
-app.config.RESPONSE_TIMEOUT = 600
+app.config.REQUEST_TIMEOUT = 120
+app.config.RESPONSE_TIMEOUT = 120
 
 
 @app.route("/status", methods=["GET"])

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -368,11 +368,8 @@ async def request_state(request):
 async def wait_for_dset(id):
     """Wait until the given dataset is present."""
     found = True
-    r = await lock_datasets.acquire()
-
-    if not await r.execute("hexists", "datasets", id):
+    if not await redis.execute("hexists", "datasets", id):
         # wait for half of kotekans timeout before we admit we don't have it
-        await lock_datasets.release()
         logger.debug("wait_for_ds: Waiting for dataset {}".format(id))
         wait_time = WAIT_TIME
         start_wait = time.time()
@@ -416,18 +413,14 @@ async def wait_for_dset(id):
                 )
             )
             found = False
-    else:
-        await lock_datasets.release()
     return found
 
 
 async def wait_for_state(id):
     """Wait until the given state is present."""
     found = True
-    r = await lock_states.acquire()
-    if not await r.execute("hexists", "states", id):
+    if not await redis.execute("hexists", "states", id):
         # wait for half of kotekans timeout before we admit we don't have it
-        await lock_states.release()
         logger.debug("wait_for_state: Waiting for state {}".format(id))
         wait_time = WAIT_TIME
         start_wait = time.time()
@@ -471,8 +464,6 @@ async def wait_for_state(id):
                 )
             )
             found = False
-    else:
-        await lock_states.release()
     return found
 
 

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -644,7 +644,7 @@ async def close_locks():
 async def _init_redis_async(_, loop):
     global redis
     redis = await aioredis.create_pool(
-        REDIS_SERVER, encoding="utf-8", minsize=20, maxsize=200
+        REDIS_SERVER, encoding="utf-8", minsize=20, maxsize=10000
     )
     await create_locks()
 


### PR DESCRIPTION
Using a timeout **around** waiting for the condition variables lead to
freeing the lock twice. To fix this, the timeout is moved into the
cond variable implementation and passed to redis.blpop.