### PR TITLE
fix(manager): make hash function python2.7 compatible

### DIFF
--- a/comet/manager.py
+++ b/comet/manager.py
@@ -385,7 +385,7 @@ class Manager:
 
     @staticmethod
     def _make_hash(data):
-        return mmh3.hash_bytes(json.dumps(data, sort_keys=True)).hex()
+        return "%032x" % mmh3.hash128(json.dumps(data, sort_keys=True), seed=1420)
 
     def get_state(self, type=None, dataset_id=None):
         """

--- a/tests/DummyClient.py
+++ b/tests/DummyClient.py
@@ -197,7 +197,7 @@ class DummyClient:
 
     @staticmethod
     def _make_hash(data):
-        return mmh3.hash_bytes(json.dumps(data, sort_keys=True)).hex()
+        return "%032x" % mmh3.hash128(json.dumps(data, sort_keys=True), seed=1420)
 
     def _send(self, endpoint, data, rtype="post"):
         command = getattr(requests, rtype)


### PR DESCRIPTION
flagging and calibration broker are written in python2 and use the manager. They don't seem to know about `str.hex()`
```
    >    File "/opt/ch_flag/ch_flag/broker.py", line 2067, in start
    >      comet.register_start(self.startup_time, __version__)
    >    File "/opt/ch_flag/venv/src/comet/comet/manager.py", line 130, in register_start
    >      state_id = self._make_hash(state)
    >    File "/opt/ch_flag/venv/src/comet/comet/manager.py", line 388, in _make_hash
    >      return mmh3.hash_bytes(json.dumps(data, sort_keys=True)).hex()
    >  AttributeError: 'str' object has no attribute 'hex'
```