### PR TITLE
fix(broker): use asyncio.gather

### DIFF
--- a/comet/broker.py
+++ b/comet/broker.py
@@ -490,12 +490,10 @@ async def gather_update(ts, roots):
                 )
 
             if tasks:
-                # Wait for all concurrent tasks
-                tasks, _ = await asyncio.wait(tasks)
+                # Wait for all concurrent tasks (gather keeps their order)
+                tasks = await asyncio.gather(*tasks)
                 # put back together the root ds IDs and the datasets
-                update.update(
-                    dict(zip(tree, [json.loads(task.result()) for task in tasks]))
-                )
+                update.update(dict(zip(tree, [json.loads(task) for task in tasks])))
     return update
 
 


### PR DESCRIPTION
Instead of asyncio.wait, use gather for keeping a list of tasks in a
specific order. This might have caused the result of /update-datasets to
get scrambled.