### PR TITLE
Manager takes care of registering start and config datasets

### DIFF
--- a/comet/archiver.py
+++ b/comet/archiver.py
@@ -6,6 +6,7 @@ Move comet broker data from redis to a mysql database
 
 import datetime
 import logging
+from peewee import DoesNotExist
 import orjson as json
 import random
 import redis
@@ -210,6 +211,15 @@ class Archiver:
             logger.error(
                 "Failure archiving dataset (DB doesn't know the referenced base dataset): {}".format(
                     data
+                )
+            )
+            self._pushback("archive_dataset", data)
+            return
+        # This is because these peewee exception names sometimes change somehow?
+        except DoesNotExist as err:
+            logger.error(
+                "Failure archiving dataset {} (DB doesn't know something referenced by it): {}".format(
+                    data, err
                 )
             )
             self._pushback("archive_dataset", data)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -111,9 +111,9 @@ def archiver(broker):
 
 @pytest.fixture(scope="session", autouse=False)
 def simple_ds(manager):
-    state_id = manager.register_state({"foo": "bar"}, "test")
-    dset_id = manager.register_dataset(state_id, None, "test", True)
-    yield (dset_id, state_id)
+    state = manager.register_state({"foo": "bar"}, "test")
+    dset = manager.register_dataset(state.id, None, "test", True)
+    yield (dset.id, state.id)
 
 
 def test_hash(manager):
@@ -253,21 +253,21 @@ def test_status(simple_ds, manager):
 
 def test_gather_update(simple_ds, manager, broker):
     root = simple_ds[0]
-    state_id = manager.register_state({"f00": "b4r"}, "t3st")
-    dset_id0 = manager.register_dataset(state_id, root, "test", False)
-    state_id = manager.register_state({"f00": "br"}, "t3st")
-    dset_id1 = manager.register_dataset(state_id, dset_id0, "test", False)
-    state_id = manager.register_state({"f00": "b4"}, "t3st")
-    dset_id2 = manager.register_dataset(state_id, dset_id1, "test", False)
+    state = manager.register_state({"f00": "b4r"}, "t3st")
+    dset0 = manager.register_dataset(state.id, root, "test", False)
+    state = manager.register_state({"f00": "br"}, "t3st")
+    dset1 = manager.register_dataset(state.id, dset0.id, "test", False)
+    state = manager.register_state({"f00": "b4"}, "t3st")
+    dset2 = manager.register_dataset(state.id, dset1.id, "test", False)
 
     result = requests.post(
         "http://localhost:{}/update-datasets".format(PORT),
-        json={"ds_id": dset_id2, "ts": 0, "roots": [root]},
+        json={"ds_id": dset2.id, "ts": 0, "roots": [root]},
     ).json()
     assert "datasets" in result
-    assert dset_id0 in result["datasets"]
-    assert dset_id1 in result["datasets"]
-    assert dset_id2 in result["datasets"]
+    assert dset0.id in result["datasets"]
+    assert dset1.id in result["datasets"]
+    assert dset2.id in result["datasets"]
 
 
 def test_get_dataset(simple_ds, manager_new, broker):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -227,9 +227,9 @@ def test_archiver_pushback(archiver):
 
     r.hset("datasets", "test_ds", json.dumps({"is_root": True, "state": "test_state"}))
     time.sleep(0.1)
-    r.llen("archive_dataset")
+    llen = r.llen("archive_dataset")
     assert llen == 1 or llen == 0
-    r.llen("archive_state")
+    llen = r.llen("archive_state")
     assert llen == 1 or llen == 0
 
     r.lpush(


### PR DESCRIPTION
- **feat(manager): register_\* take and return the objects instead of IDs**
  - the arguments state and base_dataset are allowed to be either State/Dataset objects or IDs
  - the return values of register_state and register_dataset are State and Dataset objects respectively (instead of IDs, this is a breaking change but I'm not aware of this being used anywhere)
- **feat(manager): add option register_state(register_datasets)**
  - Makes the manager take care of registering datasets attached to the start and config state. It then returns the last dataset.
  - BREAKING CHANGE: Manager.start_state and config_state are State objects now, not IDs (also not used anywhere but internally, I think)





Closes #81 