### PR TITLE
Speedup for /update-datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
     - pip install pytest-asyncio
     - pip install locust
     - pip install future  # FIXME: somehow this doesn't get installed as a dependency of caput
+    - pip install aiohttp # Needed for test_stresstest
 
 install:
     - python -m pip install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 
+### [20.6.1](https://github.com/chime-experiment/comet/compare/20.6.0...20.6.1) (2020-06-18)
+
+
+### Features
+
+* **broker:** improve failure logging ([09ebb00](https://github.com/chime-experiment/comet/commit/09ebb00e6d9a2d20303f5526b0903a5887ac1bcc))
+* **broker:** speed up /update-datasets ([ec922e9](https://github.com/chime-experiment/comet/commit/ec922e9d392c3a87cfc68d4ea881b1048d7acc7e))
+* **broker:** speed up gather_update ([6bde095](https://github.com/chime-experiment/comet/commit/6bde0954e5d915f491c074517b9766b52edbcaa4))
+
+
+
 ### [20.6.0](https://github.com/chime-experiment/comet/compare/2020.04.0...20.6.0) (2020-06-11)
 
 

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -749,7 +749,7 @@ async def update_datasets(request):
             logger.info("update-datasets: Dataset ID {} unknown.".format(ds_id))
             return response.json(reply)
 
-        if ts is 0:
+        if ts == 0:
             ts = caput_time.datetime_to_unix(datetime.datetime.min)
 
         # If the requested dataset is from a tree not known to the calling

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -527,17 +527,14 @@ async def gather_update(ts, roots):
         # The nodes in tree are ordered by their timestamp from new to
         # old, so we are done as soon as we find an older timestamp than
         # the given one.
-        tasks = []
+        datasets = []
         for n, k in zip(tree, keys):
             if k < ts:
                 break
-            tasks.append(asyncio.ensure_future(redis.execute("hget", "datasets", n)))
-
-        if tasks:
-            # Wait for all concurrent tasks (gather keeps their order)
-            tasks = await asyncio.gather(*tasks)
-            # put back together the root ds IDs and the datasets
-            update.update(dict(zip(tree, [json.loads(task) for task in tasks])))
+            datasets.append(n)
+        if datasets:
+            results = await redis.execute("hmget", "datasets", *datasets)
+            update.update(dict(zip(tree, [json.loads(task) for task in results])))
     return update
 
 

--- a/comet/broker.py
+++ b/comet/broker.py
@@ -20,6 +20,7 @@ import random
 import logging
 import redis as redis_sync
 import time
+import traceback
 
 from bisect import bisect_left
 from caput import time as caput_time
@@ -125,7 +126,12 @@ async def status(request):
         logger.debug("status: Received status request")
         return response.json({"running": True, "result": "success"})
     except Exception as e:
-        logger.error("status: received exception %s", e)
+        logger.error(
+            "status: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("status: finished")
@@ -150,7 +156,12 @@ async def get_states(request):
         logger.debug("states: {}".format(states))
         return response.json(reply)
     except Exception as e:
-        logger.error("get_states: received exception %s", e)
+        logger.error(
+            "states: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("get_states: finished")
@@ -174,7 +185,12 @@ async def get_datasets(request):
         logger.debug("datasets: {}".format(datasets))
         return response.json(reply)
     except Exception as e:
-        logger.error("get_datasets: received exception %s", e)
+        logger.error(
+            "datasets: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("get_datasets: finished")
@@ -277,7 +293,12 @@ async def register_state(request):
                 await redis.execute("hset", "requested_states", hash, time.time())
         return response.json(reply)
     except Exception as e:
-        logger.error("register-state: received exception %s", e)
+        logger.error(
+            "register-state: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("register-state: finished")
@@ -348,7 +369,12 @@ async def send_state(request):
             raise cancelled
         return response.json(reply)
     except Exception as e:
-        logger.error("send-state: received exception %s", e)
+        logger.error(
+            "send-state: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("send-state: finished")
@@ -419,7 +445,12 @@ async def register_dataset(request):
 
         return response.json(reply)
     except Exception as e:
-        logger.error("register-dataset: received exception %s", e)
+        logger.error(
+            "register-dataset: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("register-dataset: finished")
@@ -578,7 +609,12 @@ async def request_state(request):
         logger.debug("request-state: Replying with state {}".format(id))
         return response.json(reply)
     except Exception as e:
-        logger.error("request-state: received exception %s", e)
+        logger.error(
+            "request-state: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
         logger.debug("request-state: finished")
@@ -699,6 +735,7 @@ async def update_datasets(request):
     -H "Content-Type: application/json"
     http://localhost:12050/update-datasets
     """
+    start = time.time()
     try:
         ds_id = request.json["ds_id"]
         ts = request.json["ts"]
@@ -737,10 +774,15 @@ async def update_datasets(request):
         reply["result"] = "success"
         return response.json(reply)
     except Exception as e:
-        logger.error("update-datasets: received exception %s", e)
+        logger.error(
+            "update-datasets: threw exception {} while handling request from {}",
+            str(e),
+            request.ip,
+        )
+        traceback.print_exc()
         raise
     finally:
-        logger.debug("update-datasets: finished")
+        logger.debug("update-datasets: finished (took {}s)".format(time.time() - start))
 
 
 @app.route("/internal-state", methods=["GET"])

--- a/tests/test_stresstest.py
+++ b/tests/test_stresstest.py
@@ -1,0 +1,95 @@
+import aiohttp
+import asyncio
+import os
+import time
+import pytest
+import signal
+
+from datetime import datetime
+from subprocess import Popen
+
+from comet import Manager
+
+CHIMEDBRC = os.path.join(os.getcwd() + "/.chimedb_test_rc")
+CHIMEDBRC_MESSAGE = "Could not find {}.".format(CHIMEDBRC)
+PORT = "8000"
+PORT_LOW_TIMEOUT = "8080"
+
+# Some dummy states for testing:
+CONFIG = {"a": 1, "b": "fubar"}
+ABC = {"a": 0, "b": 1, "c": 2, "d": 3}
+A = {"a": 1, "b": "fubar"}
+B = {"a": 1, "b": "fubar"}
+C = {"a": 1, "b": "fuba"}
+D = {"a": 1, "c": "fubar"}
+E = {"a": 2, "b": "fubar"}
+F = {"a": 1}
+G = {"b": 1}
+H = {"blubb": "bla"}
+J = {"meta": "data"}
+
+now = datetime.utcnow()
+version = "0.7.1"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def manager_and_dataset():
+    manager = Manager("localhost", PORT)
+
+    ds = manager.register_start(now, version, CONFIG, register_datasets=True)
+    return manager, ds
+
+
+@pytest.fixture(scope="session", autouse=True)
+def broker():
+    # Tell chimedb where the database connection config is
+    assert os.path.isfile(CHIMEDBRC), CHIMEDBRC_MESSAGE
+    os.environ["CHIMEDB_TEST_RC"] = CHIMEDBRC
+
+    # Make sure we don't write to the actual chime database
+    os.environ["CHIMEDB_TEST_ENABLE"] = "Yes, please."
+
+    broker = Popen(["comet", "--debug", "1", "-p", PORT])
+
+    # wait for broker start
+    time.sleep(3)
+    yield
+    os.kill(broker.pid, signal.SIGINT)
+
+
+async def fetch(session, url, json):
+    async with session.post(url, json=json) as response:
+        return await response.text()
+
+
+async def sendalot(ds, start):
+    json = {"ds_id": ds, "ts": "0", "roots": []}
+    url = "http://localhost:{}/update-datasets".format(PORT)
+    timeout = aiohttp.ClientTimeout(total=100)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        tasks = [fetch(session, url, json) for _ in range(250)]
+        try:
+            return await asyncio.gather(*tasks)
+        except Exception as err:
+            print(str(err))
+            print(time.time() - start)
+            raise
+
+
+def test_stress_update_datasets(manager_and_dataset, broker):
+    manager, ds = manager_and_dataset
+    s1 = manager.register_state({"a": 1}, "first")
+    s2 = manager.register_state({"a": 2}, "second")
+    s3 = manager.register_state({"a": 3}, "third")
+    s4 = manager.register_state({"a": 4}, "fourth")
+    s5 = manager.register_state({"a": 5}, "fifth")
+    ds = manager.register_dataset(s1, ds, "first")
+    ds = manager.register_dataset(s2, ds, "second")
+    ds = manager.register_dataset(s3, ds, "third")
+    ds = manager.register_dataset(s4, ds, "fourth")
+    ds = manager.register_dataset(s5, ds, "fifth")
+
+    start = time.time()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(sendalot(ds.id, start))
+    print(time.time() - start)


### PR DESCRIPTION
- Remove unnecessary lock in tree()
- only call gather_update if necessary
- Use `hmget` to request multiple datasets at once

- improve error logging when endpoint throws exception