### PR TITLE
fix(broker): datasets get cached as not found permanently

### DIFF
--- a/comet/dataset.py
+++ b/comet/dataset.py
@@ -15,7 +15,7 @@ class Dataset:
         Type of the dataset state of this dataset.
     dataset_id : str
         (optional) ID (hash) of this dataset. If not supplied, it's generated internally.
-    base_dataset_id : str
+    base_dataset_id : str or None
         ID of the base dataset or `None` if this is a root dataset (default `None`).
     is_root : bool
         `True`, if this is a root dataset (default `False`).

--- a/comet/exception.py
+++ b/comet/exception.py
@@ -17,3 +17,15 @@ class BrokerError(CometError):
     """There was an error registering states or datasets with the broker."""
 
     pass
+
+
+class DatasetNotFoundError(CometError):
+    """The requested dataset was not found."""
+
+    pass
+
+
+class StateNotFoundError(CometError):
+    """The requested state was not found."""
+
+    pass

--- a/tests/kotetest.sh
+++ b/tests/kotetest.sh
@@ -5,7 +5,7 @@ set -e
 
 git clone https://github.com/kotekan/kotekan.git --branch develop --single-branch
 cd kotekan/build
-cmake -DBOOST_TESTS=ON ..
+cmake -DWITH_TESTS=ON ..
 make dataset_broker_producer dataset_broker_producer2 dataset_broker_consumer
 
 more /proc/cpuinfo | grep flags

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,6 +11,8 @@ from subprocess import Popen
 
 from comet import Manager, BrokerError, State, Dataset
 from comet.hash import hash_dictionary
+from comet.manager import REGISTER_DATASET
+
 import chimedb.dataset
 import chimedb.core
 
@@ -357,3 +359,34 @@ def test_register_start_dataset_automated(manager_and_dataset, broker):
     assert config_state.data == CONFIG
     assert start_state.data["version"] == version
     assert datetime.strptime(start_state.data["time"], "%Y-%m-%d-%H:%M:%S.%f") == now
+
+
+def test_lru_cache(broker, manager_low_timeout):
+    """Test the dataset cache doesn't cache unknown datasets as None."""
+
+    ds_id = "doesntexist"
+
+    # Request an unknown dataset
+    with pytest.raises(BrokerError):
+        manager_low_timeout.get_dataset(ds_id)
+    state = manager_low_timeout.register_state(data={"foo": "bar"}, state_type="test")
+    assert state is not None
+    assert isinstance(state, State)
+
+    # Now register it (manurally, to set the ID)
+    ds = Dataset(
+        state_id=state.id,
+        state_type="test_lru_cache",
+        dataset_id=ds_id,
+        base_dataset_id=None,
+        is_root=True,
+    )
+    request = {"hash": ds_id, "ds": ds.to_dict()}
+    result = manager_low_timeout._send(REGISTER_DATASET, request)
+    assert result is not None
+    assert result == {"result": "success"}
+
+    # Request again, it should exist now.
+    same_ds = manager_low_timeout.get_dataset(ds_id)
+    assert same_ds is not None
+    assert same_ds.to_dict() == ds.to_dict()


### PR DESCRIPTION
Solved by making the lru_cached functions raise Exceptions instead of
returning None in case they don't find what was requested and telling
the lru_cache to not cache exceptions.

Closes #87