### PR TITLE
Adjust archiver logic to avoid dropping datasets/states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ comet.egg-info
 dist
 build
 *.python-version
+
+# misc
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 comet.egg-info
 dist
 build
+*.python-version

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -51,8 +51,8 @@ except chimedb.core.exceptions.ConnectionError:
 def manager():
     manager = Manager("localhost", PORT)
 
-    manager.register_start(now, version)
-    manager.register_config(CONFIG)
+    assert manager.register_start(now, version, CONFIG) is None
+    # manager.register_config(CONFIG)
     return manager
 
 


### PR DESCRIPTION
This modifies the logic of the main comet archiver loop so that datasets/states always exist in at least one of the redis list and the chime database. 

The loop:
- Gets an entry from either the dataset or state list without removing it from that list
- Checks if the item already exists in the chime database. If so, it is removed from the redis list and the loop restarts
- Adds the item to the database
- If adding the item fails, it is moved to the back of the list under the assumption that it depends on something elsewhere in one of the lists