### PR TITLE
build: remove `<3.14` python version restriction.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.12", "3.14"]
         redis-version: ["5.0", "latest"]
 
     runs-on: ubuntu-latest
@@ -94,7 +94,7 @@ jobs:
   test-kotekan:
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         redis-version: ["5.0", "latest"]
 
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
     { name = "Don Wiebe", email = "dvw@phas.ubc.ca" }
 ]
 dynamic = ["readme", "version"]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "chimedb @ git+https://github.com/chime-experiment/chimedb.git",
     "chimedb.dataset @ git+https://github.com/chime-experiment/chimedb_dataset.git",

--- a/tests/test_stresstest.py
+++ b/tests/test_stresstest.py
@@ -117,6 +117,9 @@ def test_stress_update_datasets(manager_and_dataset, broker):
     ds = manager.register_dataset(s5, base_ds, "fifth")
 
     start = time.time()
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
     loop.run_until_complete(sendalot(ds.id, base_ds.id, root_ds_id, s5.id, start))
     print(time.time() - start)


### PR DESCRIPTION
Fixes `test_stresstest.py` to work in 3.14 (where `get_running_loop` raises `RuntimeError` if there's no currently running loop).

Closes #116